### PR TITLE
Fix(ui): Switch Next.js dev server from Turbopack to Webpack for stab…

### DIFF
--- a/hikma-pr-gui/package.json
+++ b/hikma-pr-gui/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",

--- a/hikma-pr-gui/package.json
+++ b/hikma-pr-gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hikma-pr-gui",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/commands/ui.ts
+++ b/src/commands/ui.ts
@@ -113,7 +113,7 @@ export async function startUIServer(options: { port?: number; open?: boolean } =
   console.log('');
   
   // Start the Next.js development server
-  const devProcess = spawn('npm', ['run', 'dev'], {
+  const devProcess = spawn('npm', ['exec', '--', 'next', 'dev'], {
     cwd: guiPath,
     stdio: 'inherit',
     env


### PR DESCRIPTION
…ility

The `next dev --turbopack` command in `hikma-pr-gui` was causing the UI to get stuck in a compiling state when launched via `npx hikma-pr ui`.

Switching to the default `next dev` (which uses Webpack) resolves this issue, allowing the UI to start and run correctly in this context.